### PR TITLE
Added ability to know if the clone is direct or from a relation

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,8 +76,9 @@ class Photo extends Eloquent {
 		return $this->belongsTo('Article');
 	}
 
-	public function onCloning($src) {
+	public function onCloning($src, $child = null) {
 		$this->uid = str_random();
+		if($child) echo 'This was cloned as a relation!';
 		echo 'The original key is: '.$src->getKey();
 	}
 }
@@ -85,7 +86,7 @@ class Photo extends Eloquent {
 
 The `$clone_exempt_attributes` adds to the defaults.  If you want to replace the defaults altogether, override the trait's `getCloneExemptAttributes()` method and return an array.  
 
-Also, note the `onCloning()` method in the example.  It is being used to make sure a unique column stays unique.  The `Cloneable` trait adds to no-op callbacks that get called immediately before a model is saved during a duplication and immediately after: `onCloning()` and `onCloned()`.
+Also, note the `onCloning()` method in the example.  It is being used to make sure a unique column stays unique.  The `Cloneable` trait adds to no-op callbacks that get called immediately before a model is saved during a duplication and immediately after: `onCloning()` and `onCloned()`. The `$child` parameter allows you to customize the behavior based on if it's being cloned as a relation or direct.
 
 In addition, Cloner fires the following Laravel events during cloning:
 

--- a/src/Cloneable.php
+++ b/src/Cloneable.php
@@ -85,9 +85,10 @@ trait Cloneable {
 	 * committed to the database
 	 *
 	 * @param  Illuminate\Database\Eloquent\Model $src
+	 * @param  boolean $child
 	 * @return void
 	 */
-	public function onCloning($src) {}
+	public function onCloning($src, $child = null) {}
 
 	/**
 	 * A no-op callback that gets fired when a model is cloned and saved to the

--- a/src/Cloner.php
+++ b/src/Cloner.php
@@ -100,12 +100,16 @@ class Cloner {
 	 * @param  Illuminate\Database\Eloquent\Model $clone
 	 * @param  Illuminate\Database\Eloquent\Relations\Relation $relation
 	 * @param  Illuminate\Database\Eloquent\Model $src The orginal model
+	 * @param  boolean $child
 	 * @return void
 	 */
-	protected function saveClone($clone, $relation = null, $src) {
+	protected function saveClone($clone, $relation = null, $src, $child = null) {
+
+		// Set the child flag
+		if ($relation) $child = true;
 
 		// Notify listeners via callback or event
-		if (method_exists($clone, 'onCloning')) $clone->onCloning($src);
+		if (method_exists($clone, 'onCloning')) $clone->onCloning($src, $child);
 		$this->events->fire('cloner::cloning: '.get_class($src), [$clone, $src]);
 
 		// Do the save


### PR DESCRIPTION
I ran into a use case where I don't want to change any data on a model if it is being cloned as a relationship, but if it is being cloned directly then append something to the name. Example:

```php
public function onCloning($src, $child = null) {
    if(!$child) {
	$this->name = $src->name . ' Copy';
    }
}
```