### PR TITLE
Add model's `withCount` columns ot exempt attributes

### DIFF
--- a/src/Cloneable.php
+++ b/src/Cloneable.php
@@ -25,7 +25,7 @@ trait Cloneable {
 		// Include the model count columns in the exempt columns
 		$count_columns = array_map(function($count_column) {
 		    return $count_column . '_count';
-        }, $this->withCount);
+        	}, $this->withCount);
 
 		$defaults = array_merge($defaults, $count_columns);
 

--- a/src/Cloneable.php
+++ b/src/Cloneable.php
@@ -15,12 +15,19 @@ trait Cloneable {
 	 */
 	public function getCloneExemptAttributes() {
 
-		// Alwyas make the id and timestamps exempt
+		// Always make the id and timestamps exempt
 		$defaults = [
 			$this->getKeyName(),
 			$this->getCreatedAtColumn(),
 			$this->getUpdatedAtColumn(),
 		];
+
+		// Include the model count columns in the exempt columns
+		$count_columns = array_map(function($count_column) {
+		    return $count_column . '_count';
+        }, $this->withCount);
+
+		$defaults = array_merge($defaults, $count_columns);
 
 		// It none specified, just return the defaults, else, merge them
 		if (!isset($this->clone_exempt_attributes)) return $defaults;

--- a/stubs/Article.php
+++ b/stubs/Article.php
@@ -6,6 +6,8 @@ use Illuminate\Database\Eloquent\Model as Eloquent;
 class Article extends Eloquent {
 	use Cloneable;
 
+	protected $withCount = ['photos'];
+
 	public $cloneable_relations = ['photos', 'authors', 'ratings'];
 
 	public function photos() {

--- a/tests/CloneableTest.php
+++ b/tests/CloneableTest.php
@@ -53,4 +53,8 @@ class CloneableTest extends PHPUnit_Framework_TestCase {
 		$this->assertEquals(['photos', 'authors', 'ratings', 'test'], $article->getCloneableRelations());
 	}
 
+	public function testCountColumnsAreExempt() {
+	    $article = new Article;
+	    $this->assertContains('photos_count', $article->getCloneExemptAttributes());
+    }
 }


### PR DESCRIPTION
Pull request for #16 - exclude `count` columns from cloneable attributes

I wanted to ignore the count columns that also exist as explicitly set columns on the table by doing a diff  (e.g. if a column `randoms_count` exists on the table and the column is also included in the `$withCount = ['randoms']`, it should still be included in the cloned attributes.) 

But I'm not sure how to access the connection from inside the package.

`$app['db']` inside `Schema::connection()` (facade) is NULL so I cannot call 

`Schema::connection($this->getConnection()->getName())->getColumnListing($this->getTable())` inside a function.

```
    private function getCountColumnsToExclude()
    {
        $count_columns = array_map(function($count_column) {
		    return $count_column . '_count';
        }, $this->withCount);

	return array_diff($count_columns, Schema::connection($this->getConnection()->getName())->getColumnListing($this->getTable()));
    }
```