### PR TITLE
Laravel 5.8 fix

### DIFF
--- a/src/Cloner.php
+++ b/src/Cloner.php
@@ -110,7 +110,7 @@ class Cloner {
 
 		// Notify listeners via callback or event
 		if (method_exists($clone, 'onCloning')) $clone->onCloning($src, $child);
-		$this->events->fire('cloner::cloning: '.get_class($src), [$clone, $src]);
+		$this->events->dispatch('cloner::cloning: '.get_class($src), [$clone, $src]);
 
 		// Do the save
 		if ($relation) $relation->save($clone);
@@ -118,7 +118,7 @@ class Cloner {
 
 		// Notify listeners via callback or event
 		if (method_exists($clone, 'onCloned')) $clone->onCloned($src);
-		$this->events->fire('cloner::cloned: '.get_class($src), [$clone, $src]);
+		$this->events->dispatch('cloner::cloned: '.get_class($src), [$clone, $src]);
 	}
 
 	/**

--- a/tests/FunctionalTest.php
+++ b/tests/FunctionalTest.php
@@ -49,7 +49,7 @@ class FunctionalTest extends PHPUnit_Framework_TestCase {
 	}
 
 	protected function mockEvents() {
-		return m::mock('Illuminate\Events\Dispatcher', [ 'fire' => null ]);
+		return m::mock('Illuminate\Events\Dispatcher', [ 'dispatch' => null ]);
 	}
 
 	// https://github.com/laracasts/TestDummy/blob/master/tests/FactoryTest.php#L18


### PR DESCRIPTION
In Laravel 5.4 the fire method for events was renamed to dispatch. The fire method has been an alias to dispatch until 5.8.