### PR TITLE
Pass saved clone to attachment adapter duplicate method

### DIFF
--- a/src/Adapters/Upchuck.php
+++ b/src/Adapters/Upchuck.php
@@ -47,9 +47,10 @@ class Upchuck implements AttachmentAdapter {
 	 * Duplicate a file given it's URL
 	 *
 	 * @param  string $url
+	 * @param  Illuminate\Database\Eloquent\Model $clone
 	 * @return string
 	 */
-	public function duplicate($url) {
+	public function duplicate($url, $clone) {
 
 		// Make the destination path
 		$current_path = $this->helpers->path($url);

--- a/src/AttachmentAdapter.php
+++ b/src/AttachmentAdapter.php
@@ -7,8 +7,9 @@ interface AttachmentAdapter {
 	 * a model attribute
 	 * 
 	 * @param  string $reference
+	 * @param  Illuminate\Database\Eloquent\Model $clone
 	 * @return string New reference to duplicated file
 	 */
-	public function duplicate($reference);
+	public function duplicate($reference, $clone);
 
 }

--- a/src/Cloner.php
+++ b/src/Cloner.php
@@ -45,8 +45,8 @@ class Cloner {
 	 */
 	public function duplicate($model, $relation = null) {
 		$clone = $this->cloneModel($model);
-		$this->duplicateAttachments($model, $clone);
-		$this->saveClone($clone, $relation, $model);
+        $this->saveClone($clone, $relation, $model);
+        $this->duplicateAttachments($model, $clone);
 		$this->cloneRelations($model, $clone);
 		return $clone;
 	}
@@ -91,7 +91,7 @@ class Cloner {
 		if (!$this->attachment || !method_exists($clone, 'getCloneableFileAttributes')) return;
 		foreach($clone->getCloneableFileAttributes() as $attribute) {
 			if (!$original = $model->getAttribute($attribute)) continue;
-			$clone->setAttribute($attribute, $this->attachment->duplicate($original));
+			$clone->setAttribute($attribute, $this->attachment->duplicate($original, $clone));
 		}
 	}
 


### PR DESCRIPTION
I frequently need the newly cloned model when duplicating its attachments, because when building the destination path of the cloned attachment the generated key of the cloned model is used for instance.

This is a breaking change, because I had to change the `AttachmentAdapter` signature.

**Changes**
* Added the clone as an argument to `AttachmentAdapter->duplicate()`.
* Save clone before duplicating attachments to have the key available.