### PR TITLE
Use Event Dispatcher Contract instead of class

### DIFF
--- a/src/Cloner.php
+++ b/src/Cloner.php
@@ -1,7 +1,7 @@
 <?php namespace Bkwld\Cloner;
 
 // Deps
-use Illuminate\Events\Dispatcher as Events;
+use Illuminate\Contracts\Events\Dispatcher as Events;
 use Illuminate\Support\Arr;
 
 /**


### PR DESCRIPTION
I started to use lorisleiva/actions and now cloner fails because Actions wraps the Events Dispatcher. Switching to the interface allows everything to get along.