### PR TITLE
Respect auto-increment on pivot model

### DIFF
--- a/src/Cloner.php
+++ b/src/Cloner.php
@@ -190,6 +190,11 @@ class Cloner {
 				$foreign->pivot->getCreatedAtColumn(),
 				$foreign->pivot->getUpdatedAtColumn()
 			]);
+
+	        if ($foreign->pivot->incrementing) {
+				unset($pivot_attributes[$foreign->pivot->getKeyName()]);
+	        }
+
 			$clone->$relation_name()->attach($foreign, $pivot_attributes);
 		});
 	}


### PR DESCRIPTION
Currently a duplication fails when a pivot has a primary key / auto-increment.

This PR avoids duplicating the id column when a custom pivot-model has `public $incrementing = true` set.