### PR TITLE
override user defined pivot accessor with default

### DIFF
--- a/src/Cloner.php
+++ b/src/Cloner.php
@@ -185,7 +185,7 @@ class Cloner {
 		if ($this->write_connection) return;
 
 		// Loop trough current relations and attach to clone
-		$relation->get()->each(function ($foreign) use ($clone, $relation_name) {
+		$relation->as('pivot')->get()->each(function ($foreign) use ($clone, $relation_name) {
 			$pivot_attributes = Arr::except($foreign->pivot->getAttributes(), [
 				$foreign->pivot->getRelatedKey(),
 				$foreign->pivot->getForeignKey(),


### PR DESCRIPTION
Fixes a case like: 
```php
class Article extends Eloquent {
   use \Bkwld\Cloner\Cloneable;

   protected $cloneable_relations = ['authors'];

   public function authors() {
        return $this->belongsToMany('Author')
            ->withPivot('pseudonym')
            ->as('authorship');
   }
}
```
This was giving `Call to a member function getAttributes() on null` in Bkwld\Cloner\Cloner: 195