### PR TITLE
Add extra attributes pr duplicate for use in onCloned

### DIFF
--- a/src/Cloneable.php
+++ b/src/Cloneable.php
@@ -81,7 +81,7 @@ trait Cloneable {
 	 * Clone the current model instance to a specific Laravel database connection
 	 *
 	 * @param  string $connection A Laravel database connection
-     * @param  array $attr Extra attributes for each clone
+	 * @param  array $attr Extra attributes for each clone
 	 * @return \Illuminate\Database\Eloquent\Model The new, saved clone
 	 */
 	public function duplicateTo($connection, $attr) {

--- a/src/Cloneable.php
+++ b/src/Cloneable.php
@@ -70,21 +70,22 @@ trait Cloneable {
 
 	/**
 	 * Clone the current model instance
-	 *
+	 * @param  array $attr Extra attributes for each clone
 	 * @return \Illuminate\Database\Eloquent\Model The new, saved clone
 	 */
-	public function duplicate() {
-		return App::make('cloner')->duplicate($this);
+	public function duplicate($attr = null) {
+		return App::make('cloner')->duplicate($this, null, $attr);
 	}
 
 	/**
 	 * Clone the current model instance to a specific Laravel database connection
 	 *
 	 * @param  string $connection A Laravel database connection
+     * @param  array $attr Extra attributes for each clone
 	 * @return \Illuminate\Database\Eloquent\Model The new, saved clone
 	 */
-	public function duplicateTo($connection) {
-		return App::make('cloner')->duplicateTo($this, $connection);
+	public function duplicateTo($connection, $attr) {
+		return App::make('cloner')->duplicateTo($this, $connection, $attr);
 	}
 
 	/**
@@ -93,9 +94,10 @@ trait Cloneable {
 	 *
 	 * @param  \Illuminate\Database\Eloquent\Model $src
 	 * @param  boolean $child
+     * @param  array $attr Extra attributes for each clone
 	 * @return void
 	 */
-	public function onCloning($src, $child = null) {}
+	public function onCloning($src, $child = null, $attr = null) {}
 
 	/**
 	 * A no-op callback that gets fired when a model is cloned and saved to the

--- a/src/Cloneable.php
+++ b/src/Cloneable.php
@@ -84,7 +84,7 @@ trait Cloneable {
 	 * @param  array $attr Extra attributes for each clone
 	 * @return \Illuminate\Database\Eloquent\Model The new, saved clone
 	 */
-	public function duplicateTo($connection, $attr) {
+	public function duplicateTo($connection, $attr = null) {
 		return App::make('cloner')->duplicateTo($this, $connection, $attr);
 	}
 

--- a/src/Cloner.php
+++ b/src/Cloner.php
@@ -41,7 +41,7 @@ class Cloner {
 	 *
 	 * @param  \Illuminate\Database\Eloquent\Model $model
 	 * @param  \Illuminate\Database\Eloquent\Relations\Relation $relation
-     * @param  array $attr Extra attributes for each clone
+	 * @param  array $attr Extra attributes for each clone
 	 * @return \Illuminate\Database\Eloquent\Model The new model instance
 	 */
 	public function duplicate($model, $relation = null, $attr = null) {
@@ -61,9 +61,9 @@ class Cloner {
 		$clone->save();
 
 		$this->cloneRelations($model, $clone);
-		
+
 		$this->dispatchOnClonedEvent($clone, $model);
-		
+
 		return $clone;
 	}
 
@@ -72,7 +72,7 @@ class Cloner {
 	 *
 	 * @param  \Illuminate\Database\Eloquent\Model $model
 	 * @param  string $connection A Laravel database connection
-     * @param  array $attr Extra attributes for each clone
+	 * @param  array $attr Extra attributes for each clone
 	 * @return \Illuminate\Database\Eloquent\Model The new model instance
 	 */
 	public function duplicateTo($model, $connection, $attr) {
@@ -100,7 +100,7 @@ class Cloner {
 	 * Duplicate all attachments, given them a new name, and update the attribute
 	 * value
 	 *
-		 * @param  \Illuminate\Database\Eloquent\Model $model
+     * @param  \Illuminate\Database\Eloquent\Model $model
 	 * @param  \Illuminate\Database\Eloquent\Model $clone
 	 * @return void
 	 */
@@ -116,7 +116,7 @@ class Cloner {
 	 * @param  \Illuminate\Database\Eloquent\Model $clone
 	 * @param  \Illuminate\Database\Eloquent\Relations\Relation $relation
 	 * @param  \Illuminate\Database\Eloquent\Model $src The orginal model
-     * @param  array $attr Extra attributes for each clone
+	 * @param  array $attr Extra attributes for each clone
 	 * @param  boolean $child
 	 * @return void
 	 */
@@ -195,11 +195,11 @@ class Cloner {
 				$foreign->pivot->getCreatedAtColumn(),
 				$foreign->pivot->getUpdatedAtColumn()
 			]);
-			
+
 			foreach (array_keys($pivot_attributes) as $attributeKey) {
 				$pivot_attributes[$attributeKey] = $foreign->pivot->getAttribute($attributeKey);
 			}
-			
+
 			if ($foreign->pivot->incrementing) {
 				unset($pivot_attributes[$foreign->pivot->getKeyName()]);
 			}

--- a/src/Cloner.php
+++ b/src/Cloner.php
@@ -75,7 +75,7 @@ class Cloner {
 	 * @param  array $attr Extra attributes for each clone
 	 * @return \Illuminate\Database\Eloquent\Model The new model instance
 	 */
-	public function duplicateTo($model, $connection, $attr) {
+	public function duplicateTo($model, $connection, $attr = null) {
 		$this->write_connection = $connection; // Store the write database connection
 		$clone = $this->duplicate($model, null, $attr); // Do a normal duplicate
 		$this->write_connection = null; // Null out the connection for next run


### PR DESCRIPTION
We wanted to add new values to the duplicated item, but the plugin didn't have any option to do that, so i added an attribute field to the `->duplicate()` and `->duplicateTo()` to be able to handle the values as we want within the `onCloning` event.

I think this solves #13, but not sure if it is the same thing.