### PR TITLE
Types: Cloneable::duplicate

### DIFF
--- a/src/Cloneable.php
+++ b/src/Cloneable.php
@@ -71,7 +71,7 @@ trait Cloneable {
 	/**
 	 * Clone the current model instance
 	 * @param  array $attr Extra attributes for each clone
-	 * @return \Illuminate\Database\Eloquent\Model The new, saved clone
+	 * @return self The new, saved clone
 	 */
 	public function duplicate($attr = null) {
 		return App::make('cloner')->duplicate($this, null, $attr);
@@ -82,7 +82,7 @@ trait Cloneable {
 	 *
 	 * @param  string $connection A Laravel database connection
 	 * @param  array $attr Extra attributes for each clone
-	 * @return \Illuminate\Database\Eloquent\Model The new, saved clone
+	 * @return self The new, saved clone
 	 */
 	public function duplicateTo($connection, $attr = null) {
 		return App::make('cloner')->duplicateTo($this, $connection, $attr);


### PR DESCRIPTION
Hey, hope you are well.

Currently, static analysis only knows:

```php
$newUser = $user->duplicate(); // $newUser is a Model
$newPost = $post->duplicate(); // $newUser is a Model
```

This PR would change this to:
```php
$newUser = $user->duplicate(); // $newUser is a User
$newPost = $post->duplicate(); // $newPost is a Post
```

I also applied this change to `duplicateTo` as they're very similar and I felt they should be kept consistent - but to be honest my use case only concersn `duplicate`. I'm also happy to go deeper (into some of the non-user facing code: `Cloner::duplicate` for example) if desired.

Thanks!